### PR TITLE
Add UserValve to split quey or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository provides a collection of web-based tools for interacting with Ji
 
 ## Installing Tools
 To install a tool, you must have admin privileges in your workspace. Follow these steps:
-1. Go to Workspace > Tools > “+” and paste the tool code.
+1. Go to Workspace > Tools > "+" and paste the tool code.
 2. Give the tool a name and description.
 3. Press Save to create the tool.
 4. To configure the tool, go back to Workspace > Tools, select the tool you want to configure, and click the cog icon.
@@ -20,6 +20,10 @@ This tool retrieves a Confluence page by its ID.
     - Username: example@mail.com
     - API Key: 1234ABCD
     - Base URL: https://example.atlassian.net/wiki
+- User Settings:
+    - api_key_auth: Use API key authentication (true) or personal access token (false)
+    - username: Override default username for authentication
+    - api_key: Override default API key or personal access token
 - Usage: Simply run the script and provide the Confluence page ID as an argument. The tool will return the corresponding page content.
 
 ### confluence_search.py
@@ -29,6 +33,12 @@ This tool searches for Confluence pages using a given query string.
     - Username: example@mail.com
     - API Key: 1234ABCD
     - Base URL: https://example.atlassian.net/wiki
+    - Result Limit: 5
+- User Settings:
+    - api_key_auth: Use API key authentication (true) or personal access token (false)
+    - username: Override default username for authentication
+    - api_key: Override default API key or personal access token
+    - split_query: Split the query into individual words for better search results
 - Usage: Run the script and provide the search query as an argument. The tool will return the results of the search.
 
 ### jira_issue.py
@@ -38,6 +48,10 @@ This tool retrieves Jira issues based on ID.
     - Username: example@mail.com
     - API Key: 1234ABCD
     - Base URL: https://example.atlassian.net
+- User Settings:
+    - api_key_auth: Use API key authentication (true) or personal access token (false)
+    - username: Override default username for authentication
+    - api_key: Override default API key or personal access token
 - Usage: Run the script and provide the ID as arguments. The tool will return the corresponding Jira issues.
 
 ### jira_search.py
@@ -47,6 +61,12 @@ This tool searches for Jira issues using a given query string.
     - Username: example@mail.com
     - API Key: 1234ABCD
     - Base URL: https://example.atlassian.net
+    - Result Limit: 5
+- User Settings:
+    - api_key_auth: Use API key authentication (true) or personal access token (false)
+    - username: Override default username for authentication
+    - api_key: Override default API key or personal access token
+    - split_query: Split the query into individual words for better search results
 - Usage: Run the script and provide the search query as an argument. The tool will return the results of the search.
 
 ## Contributing


### PR DESCRIPTION
Improvement: Search Term Splitting

In #1, we introduced search term splitting to enhance search functionality. However, as shown in #5, this change may not always be beneficial. The purpose of this PR is to implement a configurable UserValve for controlling the use of search term splitting.

The default value will remain set to True to maintain consistency with our previous behaviour.